### PR TITLE
fix: use GitHub's exact generate & verify algo

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,20 +113,32 @@ See
 ## Pseudocode
 
 ```go
-const dict = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+const DICT = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+const PREFIX_LEN = 4
+const CHECKSUM_LEN = 6
 
-// prefix is like 'ghp_', 'gho_', etc
 func GenerateBase62Token(prefix string, len int) string {
-    entropy := []
+    entropy := []string{}
     for 0..len {
-        index := math.RandomInt(62)
-        entropy = append(entropy, dict[index])
+        index := math.RandomInt(62) // 0..61
+        char := DICT[index]
+        entropy = append(entropy, char)
     }
     chksum := crc32.Checksum(entropy) // uint32
 
-    pad := 6
+    pad := CHECKSUM_LEN
+    chksum62 := base62.Encode(DICT, chksum, pad)
+
     // ex: "ghp_" + "zQWBuTSOoRi4A9spHcVY5ncnsDkxkJ" + "0mLq17"
-    return prefix + string(entropy) + base62.Encode(dict, chksum, pad)
+    return prefix + string(entropy) + chksum62
+}
+
+func VerifyBase62Token(token string) bool {
+    // prefix is not used
+    entropy := token[PREFIX_LEN:len(token)-CHECKSUM_LEN]
+    chksum := base62.Decode(DICT, token[len(token)-CHECKSUM_LEN:]) // uint32
+
+    return crc32.Checksum(entropy) == chksum
 }
 ```
 

--- a/base62-token.js
+++ b/base62-token.js
@@ -7,6 +7,7 @@
 
   let CRC32 = exports.CRC32 || require("crc-32");
 
+  // Knuth-Shuffle gives an even distribution, even when the random function does not
   // http://stackoverflow.com/questions/2450954/how-to-randomize-shuffle-a-javascript-array
   function _shuffle(array) {
     var currentIndex = array.length;

--- a/base62-token.js
+++ b/base62-token.js
@@ -76,9 +76,9 @@
   }
 
   function _generate(alphabet, pre, charlen) {
-    var entropy = pre + _rnd(alphabet, charlen);
+    var entropy = _rnd(alphabet, charlen);
     // Under the hood: new TextEncoder().encode(entropy)
-    var token = entropy + _checksum(alphabet, entropy);
+    var token = pre + entropy + _checksum(alphabet, entropy);
     return token;
   }
 
@@ -90,7 +90,9 @@
   }
 
   function _verify(alphabet, token) {
-    var entropy = token.slice(0, -6);
+    // skip first 4 (the prefix)
+    // exclude last 6 (the checksum)
+    var entropy = token.slice(4, -6);
     var crc = token.slice(-6);
     return crc === _checksum(alphabet, entropy);
   }
@@ -155,11 +157,8 @@
    * @params {String} alphabet - a base62 dictionary (may be sorted in any order)
    * @returns {String} - a randomized (secure) dictionary, with an entropy of 62!
    */
-  function _generateDictionary(alphabet = ALPHABET) {
-    if ("string" === typeof alphabet) {
-      alphabet = alphabet.trim().split("");
-    }
-    return _shuffle(alphabet).join("");
+  function _generateDictionary() {
+    return ALPHABET;
   }
 
   var Base62Token = {

--- a/test.js
+++ b/test.js
@@ -44,6 +44,41 @@
   }
   console.info("PASS: invalid tokens and/or dictionaries fail verification");
 
+  var fixtures = `
+    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
+    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
+    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
+    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
+    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
+    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
+    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
+    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
+    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
+    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
+    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
+    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
+    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
+    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
+    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
+    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
+    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
+    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
+    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
+    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
+  `;
+  fixtures
+    .trim()
+    .split(/\n/)
+    .forEach(function (token) {
+      token = token.trim();
+      if (!b62Token.verify(token)) {
+        throw new Error(
+          `Failed to verify actual, real-world GitHub token: ${token}`
+        );
+      }
+    });
+  console.info("PASS: verified 20 actual, real-world GitHub tokens");
+
   console.info("");
   console.info("All tests pass.");
   console.info("");


### PR DESCRIPTION
It turns out that the 4-char prefix is NOT included when generating the CRC32 checksum. This corrects that, and removes some erroneous notes on security... because I was 3am-ing.