### PR TITLE
Add longer prefixes

### DIFF
--- a/base62-token.js
+++ b/base62-token.js
@@ -91,9 +91,9 @@
   }
 
   function _verify(alphabet, token) {
-    // skip first 4 (the prefix)
+    // everything before first _ is prefix, so start directly after first _
     // exclude last 6 (the checksum)
-    var entropy = token.slice(4, -6);
+    var entropy = token.slice(token.indexOf('_') + 1, -6);
     var crc = token.slice(-6);
     return crc === _checksum(alphabet, entropy);
   }

--- a/test.js
+++ b/test.js
@@ -79,6 +79,13 @@
     });
   console.info("PASS: verified 20 actual, real-world GitHub tokens");
 
+  var longPrefix = "MoreThanFour_51PEHKkZR5PsBlXhMnRztYvUcl5km24cVLUu";
+
+  if(!b62Token.verify(longPrefix)) {
+    throw new Error("Valid token with long prefix should verify");
+  }
+  console.info("PASS: verified token with prefix greater than four characters");
+
   console.info("");
   console.info("All tests pass.");
   console.info("");


### PR DESCRIPTION
Verification starts reading after the first underscore found, as opposed to the 5th character in the string. Also adds a test case for long-prefix verification.